### PR TITLE
fixed flaky test io.github.kwahome.sopa.StructLoggerConfigTests.contextSupplierTest

### DIFF
--- a/src/test/java/io/github/kwahome/sopa/StructLoggerConfigTests.java
+++ b/src/test/java/io/github/kwahome/sopa/StructLoggerConfigTests.java
@@ -24,7 +24,7 @@
 
 package io.github.kwahome.sopa;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -140,7 +140,7 @@ public class StructLoggerConfigTests {
         StructLoggerConfig.clearContextSupplier(); // clear existing context
 
         // assert Map<String, Object> passed in is set
-        Map<String, Object> contextMap = new HashMap<>();
+        Map<String, Object> contextMap = new LinkedHashMap<>();
         contextMap.put("environment", "test");
         contextMap.put("host", "localhost");
         StructLoggerConfig.setContextSupplier(contextMap);


### PR DESCRIPTION
## What
Fixed flaky test `contextSupplierTest` in ` io.github.kwahome.sopa.StructLoggerConfigTests`.

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
./gradlew --info nondexTest --tests=io.github.kwahome.sopa.StructLoggerConfigTests.contextSupplierTest --nondexRuns=1
```

**Steps to include nonDex for gradle projects:**
Add the following text to the top of the build.gradle:

```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

Add the following line to the end of the build.gradle

```
apply plugin: 'edu.illinois.nondex'
```

If there are subprojects, add the following to the end of the build.gradle

```
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```

nonDex detects flakiness in the following line of code:

https://github.com/Suraj-Vashista-BK/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/test/java/io/github/kwahome/sopa/StructLoggerConfigTests.java#L148-L150

with the error message

> Expected: is ["host", "test", "environment", "localhost"]
         but: was ["host", "localhost", "environment", "test"]

## Why

This happens because ```contextMap``` is declared as a HashMap as shown below.
https://github.com/Suraj-Vashista-BK/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/test/java/io/github/kwahome/sopa/StructLoggerConfigTests.java#L143

During the assert we are calling ```Helpers.mapToObjectArray(contextMap)``` and the ```mapToObjectArray``` function iterates through this map as follows:

https://github.com/Suraj-Vashista-BK/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/main/java/io/github/kwahome/sopa/utils/Helpers.java#L77-L78

As, per the official [docs](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#keySet--) about ```keySet()```, the order of the values returned in not guaranteed for hash maps which can cause non determinism in the output returned.

## Fix

In order to guarantee the order of elements returned when traversed through , I have converted ```contextMap``` to  ```LinkedHashMap```.

https://github.com/Suraj-Vashista-BK/sopa-api/blob/e36e12fc5d7d72fe791898851d88c26708009f01/src/test/java/io/github/kwahome/sopa/StructLoggerConfigTests.java#L143

After this change, nonDex does not detect flakiness in the test anymore.

## Test Environment:

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic
