### PR TITLE
fixed flaky tests in the test io.github.kwahome.sopa.JSONRendererTests

### DIFF
--- a/src/test/java/io/github/kwahome/sopa/JSONRendererTests.java
+++ b/src/test/java/io/github/kwahome/sopa/JSONRendererTests.java
@@ -24,7 +24,7 @@
 
 package io.github.kwahome.sopa;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -92,10 +92,10 @@ public class JSONRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -143,10 +143,10 @@ public class JSONRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -194,10 +194,10 @@ public class JSONRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -245,10 +245,10 @@ public class JSONRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -296,10 +296,10 @@ public class JSONRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});


### PR DESCRIPTION
## What
Fixed the following flaky tests in ` io.github.kwahome.sopa.JSONRendererTests`.
1. loggingAtDebugTest
2. loggingAtErrorTest
3. loggingAtInfoTest
4. loggingAtTraceTest
5. loggingAtWarnTest

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
./gradlew --info nondexTest --tests= io.github.kwahome.sopa.JSONRendererTests.loggingAtDebugTest --nondexRuns=1
```
Other tests can also be run with nonDex following the above pattern.

**Steps to include nonDex for gradle projects:**
Add the following text to the top of the build.gradle:

```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

Add the following line to the end of the build.gradle

```
apply plugin: 'edu.illinois.nondex'
```

If there are subprojects, add the following to the end of the build.gradle

```
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```

Across all these tests, nonDex detects flakiness During the assert:

```
Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
```

with the error message

> Expected: is {"message":"On the eighth day, God started debugging!","key2":"value1","key1":"value2","map":"{key1=value1, key2=value2}","key3":"value2","key4":"value1","myMap":"{key3=value1, key4=value2}"},
 but: was {message={"message":"On the eighth day, God started debugging!","key1":"value2","key2":"value1","map":"{key2=value2, key1=value1}","key4":"value2","key3":"value1","myMap":"{key4=value2, key3=value1}"},

As we can observe, the order of elements is different.

## Why

This happens because of the following declaration:

```
Map<String, Object> map1 = new HashMap<>();
map1.put("key1", "value1");
map1.put("key2", "value2");
Map<String, Object> map2 = new HashMap<>();
map2.put("key3", "value1");
map2.put("key4", "value2");
```

while creating ```params``` which is used in ```expectedLoggingEvent``` , we are calling the ```Helpers.mapToObjectArray(map)``` helper function to convert the map to an object array wherein the ```mapToObjectArray``` function iterates through this map as follows:

https://github.com/Suraj-Vashista-BK/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/main/java/io/github/kwahome/sopa/utils/Helpers.java#L77-L78

As, per the official [docs](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#keySet--) about ```keySet()```, the order of the values returned in not guaranteed for hash maps which can cause non determinism in the output returned.

## Fix

In order to guarantee the order of elements returned when traversed through the map, I have converted ```map1``` and ```map2```  to  ```LinkedHashMap```.

```
Map<String, Object> map1 = new LinkedHashMap<>();
Map<String, Object> map2 = new LinkedHashMap<>();
```
This fix is same across all the 5 test methods mentioned initially.
After this change, nonDex does not detect flakiness in the tests anymore.

## Test Environment:

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic
