### PR TITLE
Fixed several flaky tests in io.github.kwahome.sopa.YAMLRendererTests

### DIFF
--- a/src/main/java/io/github/kwahome/sopa/renderers/YAMLRenderer.java
+++ b/src/main/java/io/github/kwahome/sopa/renderers/YAMLRenderer.java
@@ -26,6 +26,7 @@ package io.github.kwahome.sopa.renderers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.DumperOptions;
@@ -93,6 +94,7 @@ public class YAMLRenderer implements LogRenderer<Map<String, String>> {
 
     @Override
     public final String end(Logger logger, Map<String, String> builderObject) {
-        return YAML.get().dump(builderObject).trim();
+        TreeMap<String, String> treeMap = new TreeMap<>(builderObject);
+        return YAML.get().dump(treeMap).trim();
     }
 }

--- a/src/test/java/io/github/kwahome/sopa/YAMLRendererTests.java
+++ b/src/test/java/io/github/kwahome/sopa/YAMLRendererTests.java
@@ -1,6 +1,6 @@
 package io.github.kwahome.sopa;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -68,10 +68,10 @@ public class YAMLRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -82,8 +82,8 @@ public class YAMLRendererTests {
                 Helpers.mapToObjectArray(map1), object.loggableObject(), Helpers.mapToObjectArray(map2));
         expectedLoggingEvent = LoggingEvent.error(String.format(
                 "%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s", params[0], params[1], params[2], params[3],
-                params[6], params[7], params[8], params[9], "myMap", String.format("'%s'", map2), "message", message,
-                params[4], String.format("'%s'", params[5])));
+                params[6], params[7], params[8], params[9],params[4], String.format("'%s'", params[5]) , "message", message
+                , "myMap", String.format("'%s'", map2)));
         actualLoggingEvent = slf4jLogger.getLoggingEvents().get(0);
         Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
     }
@@ -119,10 +119,10 @@ public class YAMLRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -133,8 +133,8 @@ public class YAMLRendererTests {
                 Helpers.mapToObjectArray(map1), object.loggableObject(), Helpers.mapToObjectArray(map2));
         expectedLoggingEvent = LoggingEvent.warn(String.format(
                 "%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s", params[0], params[1], params[2], params[3],
-                params[6], params[7], params[8], params[9], "myMap", String.format("'%s'", map2), "message", message,
-                params[4], String.format("'%s'", params[5])));
+                params[6], params[7], params[8], params[9],params[4], String.format("'%s'", params[5]) , "message", message
+                , "myMap", String.format("'%s'", map2)));
         actualLoggingEvent = slf4jLogger.getLoggingEvents().get(0);
         Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
     }
@@ -170,10 +170,10 @@ public class YAMLRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -184,8 +184,8 @@ public class YAMLRendererTests {
                 Helpers.mapToObjectArray(map1), object.loggableObject(), Helpers.mapToObjectArray(map2));
         expectedLoggingEvent = LoggingEvent.info(String.format(
                 "%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s", params[0], params[1], params[2], params[3],
-                params[6], params[7], params[8], params[9], "myMap", String.format("'%s'", map2), "message", message,
-                params[4], String.format("'%s'", params[5])));
+                params[6], params[7], params[8], params[9],params[4], String.format("'%s'", params[5]) , "message", message
+                , "myMap", String.format("'%s'", map2)));
         actualLoggingEvent = slf4jLogger.getLoggingEvents().get(0);
         Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
     }
@@ -221,10 +221,10 @@ public class YAMLRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -235,8 +235,8 @@ public class YAMLRendererTests {
                 Helpers.mapToObjectArray(map1), object.loggableObject(), Helpers.mapToObjectArray(map2));
         expectedLoggingEvent = LoggingEvent.debug(String.format(
                 "%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s", params[0], params[1], params[2], params[3],
-                params[6], params[7], params[8], params[9], "myMap", String.format("'%s'", map2), "message", message,
-                params[4], String.format("'%s'", params[5])));
+                params[6], params[7], params[8], params[9],params[4], String.format("'%s'", params[5]) , "message", message
+                , "myMap", String.format("'%s'", map2)));
         actualLoggingEvent = slf4jLogger.getLoggingEvents().get(0);
         Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
     }
@@ -272,10 +272,10 @@ public class YAMLRendererTests {
         slf4jLogger.clear(); // clear previous log events
 
         // assert hashmap will work as well
-        Map<String, Object> map1 = new HashMap<>();
+        Map<String, Object> map1 = new LinkedHashMap<>();
         map1.put("key1", "value1");
         map1.put("key2", "value2");
-        Map<String, Object> map2 = new HashMap<>();
+        Map<String, Object> map2 = new LinkedHashMap<>();
         map2.put("key3", "value1");
         map2.put("key4", "value2");
         LoggableObject object = new GenericLoggableObject(new Object[]{"map", map1});
@@ -286,8 +286,8 @@ public class YAMLRendererTests {
                 Helpers.mapToObjectArray(map1), object.loggableObject(), Helpers.mapToObjectArray(map2));
         expectedLoggingEvent = LoggingEvent.trace(String.format(
                 "%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s", params[0], params[1], params[2], params[3],
-                params[6], params[7], params[8], params[9], "myMap", String.format("'%s'", map2), "message", message,
-                params[4], String.format("'%s'", params[5])));
+                params[6], params[7], params[8], params[9],params[4], String.format("'%s'", params[5]) , "message", message
+                , "myMap", String.format("'%s'", map2)));
         actualLoggingEvent = slf4jLogger.getLoggingEvents().get(0);
         Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
     }


### PR DESCRIPTION
## What
Fixed the following flaky tests in `io.github.kwahome.sopa.YAMLRendererTests`.
1. loggingAtDebugTest
2. loggingAtErrorTest
3. loggingAtInfoTest
4. loggingAtTraceTest
5. loggingAtWarnTest

The following command was used to detect flakiness using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
./gradlew --info nondexTest --tests=io.github.kwahome.sopa.YAMLRendererTests --nondexRuns=1
```
Other tests can also be run with nonDex following the above pattern.

**Steps to include nonDex for gradle projects:**
Add the following text to the top of the build.gradle:

```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

Add the following line to the end of the build.gradle

```
apply plugin: 'edu.illinois.nondex'
```

If there are subprojects, add the following to the end of the build.gradle

```
subprojects {
  apply plugin: 'edu.illinois.nondex'
}
```

Across all these tests, nonDex detects flakiness During the assert:

```
Assert.assertThat(actualLoggingEvent, is(expectedLoggingEvent));
```

with the error message

> LoggingEvent[throwable=Optional.absent(),marker=Optional.absent(),message=key1: value1 message: Consider this a warning!,arguments=[],level=WARN,mdc={}] but: was LoggingEvent[throwable=Optional.absent(),marker=Optional.absent(),message=message: Consider this a warning! key1: value1,arguments=[],level=WARN,mdc={}]

As we can observe, the order of elements is different. This happens for all the assert statements present in the test. Each time we are adding more key values or maps , converting them to a string message and checking them with assert equals. Each of these asserts can fail as the construction of the message string is flaky.

## Why

The flakiness is introduced in two places, first one being in the ```end``` method of ```YAMLRender.java``` as shown below:

https://github.com/Suraj-Vashista-BK/sopa-api/blob/44f5b663e7602c1ab8fc1391fb2a667444d26c05/src/main/java/io/github/kwahome/sopa/renderers/YAMLRenderer.java#L96

The ```dump``` method of Yaml package internally serializes the passed object before converting it into a string. Since we are passing a hashmap to this, there is no guarantee of order when the serialization occurs and string is created thereby causing flakiness. 

The second place where flakiness is caused is when we call the function ```Helpers.mapToObjectArray``` with hashmap which is declared in each of the test methods as shown below:

```
Map<String, Object> map1 = new HashMap<>();
map1.put("key1", "value1");
map1.put("key2", "value2");
Map<String, Object> map2 = new HashMap<>();
map2.put("key3", "value1");
map2.put("key4", "value2");
```

while creating ```params``` which is used in ```expectedLoggingEvent``` , we are calling the ```Helpers.mapToObjectArray(map)``` helper function to convert the map to an object array wherein the ```mapToObjectArray``` function iterates through this map as follows:

https://github.com/Suraj-Vashista-BK/sopa-api/blob/829b3e85bf969e742030c36a0aaf51b9518590e3/src/main/java/io/github/kwahome/sopa/utils/Helpers.java#L77-L78

As, per the official [docs](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#keySet--) about ```keySet()```, the order of the values returned in not guaranteed for hash maps which can cause non determinism in the output returned.

## Fix

For fixing the serialization error, I have converted the passed object to a ```TreeMap``` as this data structure preserves the order by sorting it when re-serializing. 

https://github.com/Suraj-Vashista-BK/sopa-api/blob/6d6ce586e249cbf5ef66214ca2568133251d03b9/src/main/java/io/github/kwahome/sopa/renderers/YAMLRenderer.java#L97-L98


In order to guarantee the order of elements returned when traversed through the map in ```Helpers.mapToObjectArray(map)``` , I have converted ```map1``` and ```map2```  to  ```LinkedHashMap```.

```
Map<String, Object> map1 = new LinkedHashMap<>();
Map<String, Object> map2 = new LinkedHashMap<>();
```

Finally, since we are sorting the message string using TreeMap based on key, we need to change our expected string as well to a sorted order as shown below:

```
expectedLoggingEvent = LoggingEvent.error(String.format( "%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s", params[0], params[1], params[2], params[3], params[6], params[7], params[8], params[9],params[4], String.format("'%s'", params[5]) , "message", message , "myMap", String.format("'%s'", map2)));
```

This fix is same across all the 5 test methods mentioned initially.
After this change, nonDex does not detect flakiness in the tests anymore.

## Test Environment:

> openjdk version "11.0.20.1"
> Apache Maven 3.6.3
> Ubuntu 20.04.6 LTS
> Linux version 5.4.0-156-generic
